### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# General reviewers (string updates)
+* @mozilla-l10n/l10n-firefox
+
+# Code reviewers (workflows, scripts)
+_scripts/ @mozilla-l10n/l10n-firefox @eemeli
+_github/workflows @mozilla-l10n/l10n-firefox @eemeli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 * @mozilla-l10n/l10n-firefox
 
 # Code reviewers (workflows, scripts)
-_scripts/ @mozilla-l10n/l10n-firefox @eemeli
-_github/workflows @mozilla-l10n/l10n-firefox @eemeli
+/_scripts/ @mozilla-l10n/l10n-firefox @eemeli
+/.github/ @mozilla-l10n/l10n-firefox @eemeli


### PR DESCRIPTION
Set the group `@mozilla-l10n/l10n-firefox` as a general reviewer for the repo, with Eemeli added for code.

Fixes #11 