### PR TITLE
Use moz.l10n diff instead of git diff

### DIFF
--- a/.github/workflows/cmp_geckostrings.yml
+++ b/.github/workflows/cmp_geckostrings.yml
@@ -25,22 +25,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: l10n
-      - name: Clone gecko-strings repository
-        run: |
-          hg clone https://hg.mozilla.org/l10n/gecko-strings
-      - name: Copy content from gecko-strings
-        run: |
-          rsync -av --quiet --exclude={".hg","_configs"} gecko-strings/ l10n/
+      - run: hg clone https://hg.mozilla.org/l10n/gecko-strings
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: l10n/_scripts/requirements.txt
+      - run: pip install -r l10n/_scripts/requirements.txt
+
       - name: Compare content
         run: |
-          diff=$(git diff --ignore-blank-lines)
+          diff=$(python l10n/_scripts/diff.py l10n gecko-strings --ignore LICENSE README.md)
           if [[ -n "$diff" ]]; then
             echo "### There are differences between the two repositories" >> $GITHUB_STEP_SUMMARY
-            echo '```diff' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
             echo "$diff" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "No differences found"
           fi
-        working-directory: l10n

--- a/_scripts/diff.py
+++ b/_scripts/diff.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Compare localization files
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from os import walk
+from os.path import commonpath, exists, join, relpath
+from sys import exit
+
+from moz.l10n.resource import UnsupportedResource, l10n_equal, parse_resource
+
+
+def diff_tree(a_root: str, b_root: str, ignore: set[str]) -> int:
+    common_root = commonpath((a_root, b_root))
+    diff_count = 0
+    b_seen: set[str] = set()
+    for dirpath, dirnames, filenames in walk(a_root):
+        dirnames[:] = [dn for dn in dirnames if not dn.startswith((".", "_"))]
+        for fn in filenames:
+            if not fn.startswith((".", "_")):
+                a_path = join(dirpath, fn)
+                rel_path = relpath(a_path, a_root)
+                if rel_path in ignore:
+                    continue
+                b_path = join(b_root, rel_path)
+                if not exists(b_path):
+                    print(f"Missing file: {relpath(b_path, common_root)}")
+                    diff_count += 1
+                elif not l10n_equal_paths(a_path, b_path):
+                    print(f"Files at {rel_path} differ")
+                    diff_count += 1
+                b_seen.add(b_path)
+    for dirpath, dirnames, filenames in walk(b_root):
+        dirnames[:] = [dn for dn in dirnames if not dn.startswith((".", "_"))]
+        for fn in filenames:
+            if not fn.startswith((".", "_")):
+                b_path = join(dirpath, fn)
+                rel_path = relpath(b_path, b_root)
+                if rel_path not in ignore and b_path not in b_seen:
+                    a_path = join(a_root, rel_path)
+                    print(f"Missing file: {relpath(a_path, common_root)}")
+                    diff_count += 1
+    return diff_count
+
+
+def l10n_equal_paths(a_path: str, b_path: str) -> bool:
+    with open(a_path, "rb") as a_file:
+        a_bytes = a_file.read()
+    with open(b_path, "rb") as b_file:
+        b_bytes = b_file.read()
+    if a_bytes == b_bytes:
+        return True
+
+    try:
+        a_res = parse_resource(a_path, a_bytes)
+    except UnsupportedResource:
+        a_res = None
+    except Exception as error:
+        print(f"parse error at {a_path}: {error}")
+        return False
+    try:
+        b_res = parse_resource(b_path, b_bytes)
+    except Exception as error:
+        if isinstance(error, UnsupportedResource) and a_res is None:
+            return True
+        else:
+            print(f"parse error at {b_path}: {error}")
+            return False
+    if a_res is None:
+        print(f"parse error at {a_path}")
+        return False
+
+    return l10n_equal(a_res, b_res)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs=2, help="root directories for the comparison")
+    parser.add_argument("--ignore", nargs="*", help="Relative paths to ignore")
+    args = parser.parse_args()
+
+    ignore = set(args.ignore) if args.ignore else set()
+    if diff_tree(args.path[0], args.path[1], ignore):
+        exit(1)

--- a/_scripts/diff.py
+++ b/_scripts/diff.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Compare localization files
+Compare messages in localization files between two paths
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ def l10n_equal_paths(a_path: str, b_path: str) -> bool:
     except UnsupportedResource:
         a_res = None
     except Exception as error:
-        print(f"parse error at {a_path}: {error}")
+        print(f"Parse error at {a_path}: {error}")
         return False
     try:
         b_res = parse_resource(b_path, b_bytes)
@@ -70,10 +70,10 @@ def l10n_equal_paths(a_path: str, b_path: str) -> bool:
         if isinstance(error, UnsupportedResource) and a_res is None:
             return True
         else:
-            print(f"parse error at {b_path}: {error}")
+            print(f"Parse error at {b_path}: {error}")
             return False
     if a_res is None:
-        print(f"parse error at {a_path}")
+        print(f"Parse error at {a_path}")
         return False
 
     return l10n_equal(a_res, b_res)
@@ -81,7 +81,7 @@ def l10n_equal_paths(a_path: str, b_path: str) -> bool:
 
 if __name__ == "__main__":
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument("path", nargs=2, help="root directories for the comparison")
+    parser.add_argument("path", nargs=2, help="Root directories for the comparison")
     parser.add_argument("--ignore", nargs="*", help="Relative paths to ignore")
     args = parser.parse_args()
 

--- a/_scripts/requirements.txt
+++ b/_scripts/requirements.txt
@@ -1,2 +1,3 @@
 compare-locales ~= 9.0.2
+moz.l10n ~= 0.1.1
 tomli-w ~= 1.0.0


### PR DESCRIPTION
This uses the purpose-built `l10n_equal()` comparison function from `moz.l10n.resource`, which ignores irrelevant details like message order.

~Filed initially as a draft, pending on mozilla/moz-l10n#9 and a subsequent release of moz.l10n v0.1.1.~
Edit: Done.